### PR TITLE
Allow defaultAuthor to be defined in config.json

### DIFF
--- a/lib/commands/post.js
+++ b/lib/commands/post.js
@@ -1,10 +1,16 @@
 var smith   = require("../blacksmith"),
     fs2      = require('../fs2'),
     winston = require('winston'),
+	path = require('path'),
     prompt  = require("prompt");
 
 module.exports = function() {
   winston.info("Executing command "+"post".yellow);
+
+  if(smith.config.global.store.defaultAuthor && path.existsSync('./authors/'+smith.config.global.store.defaultAuthor+'.json')) {
+      var authors = require("../loaders/authors").load(true);
+      var defaultAuthor = authors[smith.config.global.store.defaultAuthor].file.store.name;
+  }
 
   prompt.start();
   prompt.get([
@@ -14,13 +20,16 @@ module.exports = function() {
     },
     {
       name: "author",
-      message: "Specify the author"
+      message: "Specify the author" + (defaultAuthor ? " (empty to use '"+defaultAuthor+"')" : "")
     }
   ], function (err, res) {
     if (err) {
       winston.error(err.stack);
       cb(1);
     }
+
+    if(res.author === "")
+      res.author = smith.config.global.store.defaultAuthor;
 
     var folder = res.title.toLowerCase().replace(/\W+/g, '-');
 


### PR DESCRIPTION
If defaultAuthor: "derp" and authors/derp.json are both present the specify author prompt with be replaced with

Specify the author (empty to use 'I AM DERP')

Where 'I am DERP' is the value of config.defaultAuthor
