### PR TITLE
allow contentDir to be defined in config.json

### DIFF
--- a/lib/commands/post.js
+++ b/lib/commands/post.js
@@ -1,10 +1,16 @@
 var smith   = require("../blacksmith"),
     fs2      = require('../fs2'),
     winston = require('winston'),
+	path = require('path'),
     prompt  = require("prompt");
 
 module.exports = function() {
   winston.info("Executing command "+"post".yellow);
+
+  if(smith.config.global.store.defaultAuthor && path.existsSync('./authors/'+smith.config.global.store.defaultAuthor+'.json')) {
+      var authors = require("../loaders/authors").load(true);
+      var defaultAuthor = authors[smith.config.global.store.defaultAuthor].file.store.name;
+  }
 
   prompt.start();
   prompt.get([
@@ -14,13 +20,16 @@ module.exports = function() {
     },
     {
       name: "author",
-      message: "Specify the author"
+      message: "Specify the author" + (defaultAuthor ? " (empty to use '"+defaultAuthor+"')" : "")
     }
   ], function (err, res) {
     if (err) {
       winston.error(err.stack);
       cb(1);
     }
+
+    if(res.author === "")
+      res.author = smith.config.global.store.defaultAuthor;
 
     var folder = res.title.toLowerCase().replace(/\W+/g, '-');
 

--- a/lib/commands/post.js
+++ b/lib/commands/post.js
@@ -33,6 +33,9 @@ module.exports = function() {
 
     var folder = res.title.toLowerCase().replace(/\W+/g, '-');
 
+    if(smith.config.global.store.contentDir)
+      folder = smith.config.global.store.contentDir + "/" + folder;
+
     //TODO: Check authors
 
     winston.warn('blacksmith'.yellow+' is about to write '

--- a/lib/commands/post.js
+++ b/lib/commands/post.js
@@ -1,15 +1,19 @@
 var smith   = require("../blacksmith"),
     fs2      = require('../fs2'),
     winston = require('winston'),
-	path = require('path'),
+    path = require('path'),
     prompt  = require("prompt");
 
 module.exports = function() {
   winston.info("Executing command "+"post".yellow);
 
-  if(smith.config.global.store.defaultAuthor && path.existsSync('./authors/'+smith.config.global.store.defaultAuthor+'.json')) {
-      var authors = require("../loaders/authors").load(true);
-      var defaultAuthor = authors[smith.config.global.store.defaultAuthor].file.store.name;
+  var defaultAuthor = smith.config.get("defaultAuthor"),
+      defaultAuthorName;
+  if(defaultAuthor && path.existsSync('./authors/'+defaultAuthor+'.json')) {
+    var author = require("../loaders/authors").load(true)[defaultAuthor];
+    if(author) {
+      defaultAuthorName = author.get("name");
+    }
   }
 
   prompt.start();
@@ -20,7 +24,7 @@ module.exports = function() {
     },
     {
       name: "author",
-      message: "Specify the author" + (defaultAuthor ? " (empty to use '"+defaultAuthor+"')" : "")
+      message: "Specify the author" + (defaultAuthorName ? " (empty to use '"+defaultAuthorName+"')" : "")
     }
   ], function (err, res) {
     if (err) {
@@ -28,13 +32,11 @@ module.exports = function() {
       cb(1);
     }
 
-    if(res.author === "")
-      res.author = smith.config.global.store.defaultAuthor;
+    if(res.author === "") {
+      res.author = defaultAuthorName;
+    }
 
     var folder = res.title.toLowerCase().replace(/\W+/g, '-');
-
-    if(smith.config.global.store.contentDir)
-      folder = smith.config.global.store.contentDir + "/" + folder;
 
     //TODO: Check authors
 


### PR DESCRIPTION
Sorry for double commit, this should only be for aa4a274d
When defining contentDir in config.json `blacksmith post` will output content to that location.
