### PR TITLE
Fix wrong title in archives, website title instead of article title

### DIFF
--- a/lib/renderers/archive.js
+++ b/lib/renderers/archive.js
@@ -73,8 +73,10 @@ archive.weld = function(dom, pages) {
           throw err;
         }
 
+        //Uses the title which is inside the article tag
+        //do not confuse with the blog title
         var article = $(".content", dom).html(),
-            title = $(".title", dom).html(),
+            title = $("article > .title", dom).html(),
             rm = false;
 
         // As with the article, we've already "rendered" the title (with link),


### PR DESCRIPTION
The archive was using the first .title element but in the
default template the first .title is the site's title.
Now it uses the first .title inside the article (article > .title)

This fix the issue #42

thanks. 
