### PR TITLE
Subdirectory blog location support, ex. www.somewhere.net/blog

### DIFF
--- a/lib/blacksmith.js
+++ b/lib/blacksmith.js
@@ -34,7 +34,11 @@ smith.config = nconf;
 if (path.existsSync('./config.json')) {
   smith.config.add("global", { type: "file", file: "./config.json"});
 
-  smith.config.set('path', require('url').parse('http://'+(smith.config.get('url') || "")).pathname);
+  var pathname = require('url').parse('http://'+(smith.config.get('url') || "")).pathname;
+  if (pathname == '/') {
+    pathname = '';
+  }
+  smith.config.set('path', pathname);
 }
 
 // smith.loaders is a list of key/value pairs so we can depend on method

--- a/lib/blacksmith.js
+++ b/lib/blacksmith.js
@@ -33,6 +33,8 @@ smith.config = nconf;
 // Try to load configuration if the file exists.
 if (path.existsSync('./config.json')) {
   smith.config.add("global", { type: "file", file: "./config.json"});
+
+  smith.config.set('path', require('url').parse('http://'+(smith.config.get('url') || "")).pathname);
 }
 
 // smith.loaders is a list of key/value pairs so we can depend on method

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,7 +82,7 @@ helpers.treeToHTML = function(values, parent) {
       var key = Object.keys(val)[0];
     }
     if (typeof values[i]=='object' && values[i] != null){
-      var newParent = parent || '';
+      var newParent = parent || (smith.config.get('path') || "");
       newParent = newParent + '/' + key;
 
       var link = newParent;

--- a/lib/loaders/rss.js
+++ b/lib/loaders/rss.js
@@ -17,8 +17,8 @@ rss.load = function () {
   return new Rss({
     title: smith.config.get("title") || "",
     description: smith.config.get("description") || "",
-    feed_url: '/feed.xml',
-    site_url: smith.config.get("url") || "",
+    feed_url: 'http://' + smith.config.get("url") + '/feed.xml',
+    site_url: 'http://' + smith.config.get("url") || "",
     author: smith.config.get("author") || ""
   });
 };

--- a/lib/renderers/content.js
+++ b/lib/renderers/content.js
@@ -210,7 +210,7 @@ content.weld = function(dom, pages) {
             $(element).text("");
             $(element).append(
               $("<a>")
-                .attr("href", helpers.unresolve(smith.src, metadata.link))
+                .attr("href", (smith.config.get("path") || "")+helpers.unresolve(smith.src, metadata.link).substring(1))
                 .text(val)
             );
           }


### PR DESCRIPTION
This may be usefull feature if you want to place your blog in subdirectory.

url variable in config.json can now include path, ex. "url": "www.somewhere.net/blog"
All generated links will be prefixed with /blog
