### PR TITLE
table.buildToc() does not always returns all the articles of an author.

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -24,7 +24,17 @@ table.buildToc = function (options) {
   if (options.author) {
     content = Hash.filter(content, function (v, k) {
       if (v.metadata && v.metadata.author) {
-        return v.metadata.author === options.author;
+        if (typeof v.metadata.author === "string") {
+          return v.metadata.author === options.author;
+        }
+
+        // When a page has already been rendered its metadata is
+        // a raw object of the configuration data.
+        if (v.metadata.author._id) {
+          return v.metadata.author._id === options.author;
+        }
+
+        return false;
       }
       return false;
     });


### PR DESCRIPTION
When an article has been rendered the content renderer updates the author property of the page metadata.
This update has the consequence to break the filtering of articles by author because the returned value is always false :

``` javascript
if (v.metadata && v.metadata.author) {
    // returns false because the v.metadata.author value is no longer a string.
    return v.metadata.author === options.author;
}
```
