### PR TITLE
Toc structure

### DIFF
--- a/lib/renderers/archive.js
+++ b/lib/renderers/archive.js
@@ -57,7 +57,7 @@ archive.weld = function(dom, pages) {
   // Function for grabbing the top x elements from the ToC
   var tocLast = function (len) {
     return $('<ul>').append($($(toc).html()).slice(0, len))[0].outerHTML;
-  }
+  };
 
   pages.forEach(function (file) {
     var metadata = content[file].metadata || {},

--- a/lib/renderers/archive.js
+++ b/lib/renderers/archive.js
@@ -56,7 +56,7 @@ archive.weld = function(dom, pages) {
 
   // Function for grabbing the top x elements from the ToC
   var tocLast = function (len) {
-    return $('<ul>').append($($(toc).html()).slice(0, len)).html();
+    return $('<ul>').append($($(toc).html()).slice(0, len))[0].outerHTML;
   }
 
   pages.forEach(function (file) {

--- a/lib/renderers/content.js
+++ b/lib/renderers/content.js
@@ -33,7 +33,7 @@ content.weld = function(dom, pages) {
   // Function for grabbing the top x elements from the ToC
   var tocLast = function (len) {
     return $('<ul>').append($($(toc).html()).slice(0, len))[0].outerHTML;
-  }
+  };
 
   Object.keys(pages).forEach( function (i) {
 

--- a/lib/renderers/content.js
+++ b/lib/renderers/content.js
@@ -32,7 +32,7 @@ content.weld = function(dom, pages) {
 
   // Function for grabbing the top x elements from the ToC
   var tocLast = function (len) {
-    return $('<ul>').append($($(toc).html()).slice(0, len)).html();
+    return $('<ul>').append($($(toc).html()).slice(0, len))[0].outerHTML;
   }
 
   Object.keys(pages).forEach( function (i) {


### PR DESCRIPTION
When the toc.length property is defined in the page.json metadata, the tocLast() function return an invalid html tree and the final content of the nav element is :

``` html
<nav>
    <li></li>
</nav>
```

The fix ensure that the nav element looks like :

``` html
<nav>
    <ul>
        <li></li>
    </ul>
</nav>
```
