### PR TITLE
Adding main entrypoint to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "bin": {
     "blacksmith": "bin/blacksmith"
   },
+  "main": "lib/blacksmith",
   "devDependencies": {
     "vows": "0.6.x"
   },


### PR DESCRIPTION
Currently there is no way to require('blacksmith') and call blacksmith from inside code context. The only way to invoke blacksmith is to call the command line.

This allows another module to require blacksmith.
