### PR TITLE
Fix for Node 10.x path lib

### DIFF
--- a/lib/blacksmith/site.js
+++ b/lib/blacksmith/site.js
@@ -515,7 +515,7 @@ Site.prototype.targetFiles = function (rendered, pathTo) {
         all = all.concat(rendered[key]._content.files.map(function (file) {
           return {
             fullpath: path.join.apply(path, fullpath.concat([path.basename(file)])),
-            source: path.join(contentDir, rendered[key].dir, file)
+            source: path.join(contentDir, rendered[key].dir || '', file)
           };
         }));
       }


### PR DESCRIPTION
Currently, running `blacksmith` in node 10.x throws a type error:

``` shell
$ blacksmith
Rendering: /blog

path.js:360
        throw new TypeError('Arguments to path.join must be strings');
              ^
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at Object.exports.join (path.js:358:36)
    at /node_modules/blacksmith/lib/blacksmith/site.js:518:26
    at Array.map (native)
    at /node_modules/blacksmith/lib/blacksmith/site.js:515:55
    at Array.reduce (native)
    at Site.targetFiles (/node_modules/blacksmith/lib/blacksmith/site.js:474:32)
    at /node_modules/blacksmith/lib/blacksmith/site.js:529:29
    at Array.reduce (native)
```
